### PR TITLE
Add ReputationTracker Clarity smart contract with badge leaderboard functionality

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# ReputationTracker Smart Contract
+
+A simple badge leaderboard system built with Clarity for the Stacks blockchain.
+
+## Overview
+
+ReputationTracker enables an admin to award badges to users and keeps track of badge counts per user. It also provides functions to query badge counts and compare users for leaderboard purposes.
+
+## Features
+
+- **Award Badges:** Only the contract owner can award badges to users.
+- **Query Badges:** Anyone can check how many badges a user has.
+- **Leaderboard:** Compare two users and return the one with more badges.
+
+## Contract Functions
+
+| Function            | Access      | Description                                      |
+|---------------------|-------------|--------------------------------------------------|
+| `award-badge`       | Public      | Admin awards a badge to a user                   |
+| `get-user-badges`   | Read-only   | Returns the badge count for a user               |
+| `get-leader`        | Read-only   | Compares two users and returns the leader        |
+
+## Usage Examples
+
+### Award a Badge
+
+```clarity
+(award-badge 'ST123...456)
+```
+*Only the contract owner can call this function.*
+
+### Get User Badges
+
+```clarity
+(get-user-badges 'ST123...456)
+```
+
+### Compare Two Users
+
+```clarity
+(get-leader 'ST123...456 'ST789...012)
+```
+
+## Security Notes
+
+- All user input is type-checked as `principal`.
+- All map lookups use `default-to` to ensure safe default values.
+- Only the contract owner can award badges.
+

--- a/contracts/ReputationTracker.clar
+++ b/contracts/ReputationTracker.clar
@@ -1,0 +1,64 @@
+;; A simple badge leaderboard system
+;; Author: ChatGPT | Project 33
+
+;; =========================
+;; CONFIGURATION
+;; =========================
+
+;; Set the contract owner (change to your deployer address if needed)
+(define-constant contract-owner 'ST000000000000000000002AMW42H)
+
+;; =========================
+;; STORAGE
+;; =========================
+
+;; Store number of badges per user
+(define-map user-badges
+  { user: principal }
+  { count: uint }
+)
+
+;; =========================
+;; FUNCTIONS
+;; =========================
+
+;; Award a badge to a user (admin only)
+(define-public (award-badge (user principal))
+  (begin
+    ;; Only the contract owner can award badges
+    (asserts! (is-eq tx-sender contract-owner) (err "Only contract owner can award badges"))
+
+    ;; Get current badge count (default to 0)
+    ;; LSP warning: 'user' is untrusted input, but is only used as a map key (safe)
+    (let ((current (default-to u0 (get count (map-get? user-badges {user: user})))))
+
+      ;; 'current' is always a uint due to 'default-to', so this is safe
+      (map-set user-badges {user: user} {count: (+ current u1)})
+
+      (ok (+ current u1))
+    )
+  )
+)
+
+;; Get how many badges a user has
+(define-read-only (get-user-badges (user principal))
+  ;; LSP warning: potentially unchecked data, but 'default-to' ensures a value is always returned (safe)
+  (ok (default-to u0 (get count (map-get? user-badges {user: user}))))
+)
+
+;; Compare two users and return the one with more badges
+(define-read-only (get-leader (user1 principal) (user2 principal))
+  ;; LSP warning: potentially unchecked data, but 'default-to' ensures a value is always returned (safe)
+  (let (
+    (badges1 (default-to u0 (get count (map-get? user-badges {user: user1}))))
+    (badges2 (default-to u0 (get count (map-get? user-badges {user: user2}))))
+  )
+    (if (> badges1 badges2)
+        (ok user1)
+        (if (> badges2 badges1)
+            (ok user2)
+            (ok user1) ;; tie, return user1 as default
+        )
+    )
+  )
+)


### PR DESCRIPTION
This PR introduces the initial version of the ReputationTracker smart contract for the Stacks blockchain. The contract allows the admin (contract owner) to award badges to users, keeps track of badge counts per user, and provides read-only functions to query badge counts and compare users for leaderboard purposes.

Key Features:

Only the contract owner can award badges to users.
Anyone can query the number of badges a user has.
Compare two users and return the one with more badges.
All user input is type-checked and map lookups use safe defaults.
Includes:

Clarity contract source code

Documentation and comments for clarity and security
[.gitattributes](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) for repository configuration